### PR TITLE
Add game announcements

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -41,7 +41,11 @@ cat << EOF > src/private/config.json
     "roles": {
         "admin_access": 0
     },
-    "server_url": "https://example.com"
+    "server_url": "https://example.com",
+    "games": {
+        "announcement_channel": 0,
+        "announcement_time": "12:00 AM"
+    }
 }
 EOF
 

--- a/src/commands.py
+++ b/src/commands.py
@@ -13,6 +13,9 @@ ADMIN_HELP_MES = (
     "Remove a custom message: `{prefix}remove NAME`\n"
     "Speak a message as the bot: `{prefix}say CHAN_ID message`\n"
     "View your XP: `{prefix}xp`\n"
+    "\nAdd a game to be announced: `{prefix}addgame game_info`\n"
+    "View all games to be announced: `{prefix}getgames`\n"
+    "Remove all games to be announced: `{prefix}cleargames`\n"
     "\nView this message: `{prefix}help`".format(prefix=CMD_PREFIX)
 )
 

--- a/src/commands.py
+++ b/src/commands.py
@@ -65,12 +65,8 @@ Say
 
 Speaks a message to the specified channel as the bot
 """
+@utils.requires_admin
 async def say(message):
-    # Only allow if user has correct permissions
-    roles = [x.id for x in message.author.roles]
-    if ADMIN_ACCESS not in roles:
-        return None
-
     try:
         payload = utils.remove_command(message.content)
         channel_id = utils.get_command(payload)
@@ -96,12 +92,8 @@ Edit message
 
 Edits a message spoken by the bot, by message ID
 """
+@utils.requires_admin
 async def edit(message):
-    # Only allow if user has correct permissions
-    roles = [x.id for x in message.author.roles]
-    if ADMIN_ACCESS not in roles:
-        return None
-
     try:
         payload = utils.remove_command(message.content)
         edit_id = utils.get_command(payload)
@@ -185,12 +177,8 @@ class CustomCommands:
 
     Input: message - Discord message object
     """
+    @utils.requires_admin
     async def define_cmd(self, message):
-        # Only allow if user has correct permissions
-        roles = [x.id for x in message.author.roles]
-        if ADMIN_ACCESS not in roles:
-            return None
-
         # First remove the "define" command
         new_cmd = utils.remove_command(message.content)
         # Then parse the new command
@@ -228,12 +216,8 @@ class CustomCommands:
 
     Input: message - Discord message object
     """
+    @utils.requires_admin
     async def remove_cmd(self, message):
-        # Only allow if user has correct permissions
-        roles = [x.id for x in message.author.roles]
-        if ADMIN_ACCESS not in roles:
-            return None
-
         # First remove the "define" command
         new_cmd = utils.remove_command(message.content)
         # Then parse the command to remove

--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import json
 
 XP_PER_LVL = 300
@@ -13,6 +14,9 @@ ADMIN_ACCESS = cfg['roles']['admin_access']
 SERVER_URL = cfg['server_url']
 OWNER = cfg['owner']
 DEBUG_BOT = (cfg['debug'].upper() == "TRUE")
+
+GAME_ANNOUNCEMENT_CHANNEL = cfg['games']['announcement_channel']
+GAME_ANNOUNCE_TIME = datetime.strptime(cfg['games']['announcement_time'], "%I:%M %p")
 
 # Import ranks from their configuration
 with open(cfg['ranks_path']) as ranks_file:

--- a/src/db.py
+++ b/src/db.py
@@ -118,3 +118,50 @@ def get_rank(userid):
         return None
 
     return results[0]
+
+"""
+Add game
+
+Adds a new stored game to the database
+
+Inputs:
+    - game - A link to the game plus any additional info about the game - str
+"""
+def add_game(game):
+    sqlconn = sqlite3.connect(DB_PATH)
+
+    sqlconn.execute("INSERT INTO games (game) VALUES (?)", [game])
+
+    sqlconn.commit()
+    sqlconn.close()
+
+"""
+Get games
+
+Gets all games stored
+"""
+def get_games():
+    sqlconn = sqlite3.connect(DB_PATH)
+
+    # get games as a list of 1-tuples
+    raw_results = sqlconn.execute("SELECT game FROM games").fetchall()
+
+    # convert games into a list of strings
+    results = [game[0] for game in raw_results]
+
+    sqlconn.close()
+
+    return results
+
+"""
+Clear games
+
+Removes all currently stored games
+"""
+def clear_games():
+    sqlconn = sqlite3.connect(DB_PATH)
+
+    sqlconn.execute("DELETE FROM games")
+
+    sqlconn.commit()
+    sqlconn.close()

--- a/src/games.py
+++ b/src/games.py
@@ -1,7 +1,7 @@
-import db, utils, config
+import db, utils
 from datetime import datetime, timedelta, timezone
 import asyncio, random
-from config import ADMIN_ACCESS
+from config import GAME_ANNOUNCE_TIME
 
 ANNOUNCE_MESSAGES = [
     "Oh ho ho, what are all these free games I've found?",
@@ -47,25 +47,11 @@ class GameTimer:
 
 
 """
-Requires admin
-
-Wrapper function for commands that has them do nothing if the author doesn't have the admin role
-"""
-def requires_admin(func):
-    async def wrapper(message):
-        roles = [x.id for x in message.author.roles]
-        if ADMIN_ACCESS not in roles:
-            return None
-
-        return await func(message)
-    return wrapper
-
-"""
 Add game
 
 Adds a game to be announced
 """
-@requires_admin
+@utils.requires_admin
 async def add_game(message):
     game = utils.remove_command(message.content).strip()
     if len(game) == 0:
@@ -84,7 +70,7 @@ Get games
 
 Returns the list of games to be announced
 """
-@requires_admin
+@utils.requires_admin
 async def get_games(message):
     games = db.get_games()
 
@@ -102,7 +88,7 @@ Clear games
 
 Clears all games that are being announced
 """
-@requires_admin
+@utils.requires_admin
 async def clear_games(message):
     db.clear_games()
 
@@ -115,7 +101,7 @@ Get next announcement info
 Returns a string representing the time when the next game announcement will happen. Inlcudes the UTC time and duration until that time.
 """
 def get_next_announcement_info():
-    time_utc = config.GAME_ANNOUNCE_TIME.strftime("%H:%M UTC")
+    time_utc = GAME_ANNOUNCE_TIME.strftime("%H:%M UTC")
     remaining = get_delta_to_next_announcement()
 
     hours, remainder = divmod(remaining.total_seconds(), 3600)
@@ -128,11 +114,11 @@ Get delta to next announcement
 
 Gets a timedelta to the next announcement time.
 
-If the current time today is before the configured time, the timedelta will be to the announcement time today. Otherwill it will be for the announcement time tomorrow.
+If the current time today is before the configured time, the timedelta will be to the announcement time today. Otherwise it will be for the announcement time tomorrow.
 """
 def get_delta_to_next_announcement():
     now = datetime.now(timezone.utc)
-    announcement = now.replace(day=now.day, hour=config.GAME_ANNOUNCE_TIME.hour, minute=config.GAME_ANNOUNCE_TIME.minute)
+    announcement = now.replace(hour=GAME_ANNOUNCE_TIME.hour, minute=GAME_ANNOUNCE_TIME.minute)
 
     if announcement <= now:
         announcement += timedelta(days=1)

--- a/src/games.py
+++ b/src/games.py
@@ -1,0 +1,140 @@
+import db, utils, config
+from datetime import datetime, timedelta, timezone
+import asyncio, random
+from config import ADMIN_ACCESS
+
+ANNOUNCE_MESSAGES = [
+    "Oh ho ho, what are all these free games I've found?",
+    "Wow, I still remember how delicious the Luau soup was. Here are some free games:",
+    "Here are today's free games!"
+]
+
+"""
+Game Timer
+
+Manages sending out game announcements at a regular interval.
+Can only handle one announcement channel for one server.
+"""
+class GameTimer:
+    def start(self, channel):
+        self._channel = channel
+
+        asyncio.create_task(self._announce_games())
+
+    async def _announce_games(self):
+        while True:
+            await self._wait_until_next_announcement()
+
+            games = db.get_games()
+
+            if len(games) != 0:
+                # generate message
+                formatted_games = "\n".join(games)
+                announcement = random.choice(ANNOUNCE_MESSAGES)
+                message = f"{announcement}\n\n{formatted_games}"
+
+                # send message
+                await self._channel.send(message)
+
+                # clear games
+                db.clear_games()
+
+    @staticmethod
+    async def _wait_until_next_announcement():
+        next_announcement = get_delta_to_next_announcement()
+
+        await asyncio.sleep(next_announcement.total_seconds())
+
+
+"""
+Requires admin
+
+Wrapper function for commands that has them do nothing if the author doesn't have the admin role
+"""
+def requires_admin(func):
+    async def wrapper(message):
+        roles = [x.id for x in message.author.roles]
+        if ADMIN_ACCESS not in roles:
+            return None
+
+        return await func(message)
+    return wrapper
+
+"""
+Add game
+
+Adds a game to be announced
+"""
+@requires_admin
+async def add_game(message):
+    game = utils.remove_command(message.content).strip()
+    if len(game) == 0:
+        return "Can't add game: no message provided."
+
+    db.add_game(game)
+
+    total_games = len(db.get_games())
+
+    time_info = get_next_announcement_info()
+
+    return f"Game added! {total_games} game(s) will be announced at {time_info}."
+
+"""
+Get games
+
+Returns the list of games to be announced
+"""
+@requires_admin
+async def get_games(message):
+    games = db.get_games()
+
+    time_info = get_next_announcement_info()
+
+    if len(games) != 0:
+        formatted_games = "\n".join(games)
+
+        return f"The following games will be announced at {time_info}:\n{formatted_games}"
+    else:
+        return f"There are no games to announce so the next announcement at {time_info} will be skipped."
+
+"""
+Clear games
+
+Clears all games that are being announced
+"""
+@requires_admin
+async def clear_games(message):
+    db.clear_games()
+
+    return "Games cleared!"
+
+
+"""
+Get next announcement info
+
+Returns a string representing the time when the next game announcement will happen. Inlcudes the UTC time and duration until that time.
+"""
+def get_next_announcement_info():
+    time_utc = config.GAME_ANNOUNCE_TIME.strftime("%H:%M UTC")
+    remaining = get_delta_to_next_announcement()
+
+    hours, remainder = divmod(remaining.total_seconds(), 3600)
+    minutes, _ = divmod(remainder, 60)
+
+    return f"{time_utc} ({int(hours)}h{int(minutes)}m left)"
+
+"""
+Get delta to next announcement
+
+Gets a timedelta to the next announcement time.
+
+If the current time today is before the configured time, the timedelta will be to the announcement time today. Otherwill it will be for the announcement time tomorrow.
+"""
+def get_delta_to_next_announcement():
+    now = datetime.now(timezone.utc)
+    announcement = now.replace(day=now.day, hour=config.GAME_ANNOUNCE_TIME.hour, minute=config.GAME_ANNOUNCE_TIME.minute)
+
+    if announcement <= now:
+        announcement += timedelta(days=1)
+    
+    return announcement - now

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,3 +1,5 @@
+from config import ADMIN_ACCESS
+
 """
 Strip prefix
 
@@ -30,3 +32,20 @@ Input: mes - message to modify - str
 def remove_command(mes):
     request = mes.split()[1:]
     return " ".join(request)
+
+"""
+Requires admin
+
+Wrapper function for commands that has them do nothing if the author doesn't have the admin role
+"""
+def requires_admin(func):
+    async def wrapper(*args, **kwargs):
+        # expect message to be the last argument
+        message = args[-1]
+
+        roles = [x.id for x in message.author.roles]
+        if ADMIN_ACCESS not in roles:
+            return None
+
+        return await func(*args, **kwargs)
+    return wrapper


### PR DESCRIPTION
This PR adds support for Governor to keep track of and automatically post game announcements so we don't forget.

### Server Usage

We add games when we learn about them:
```
!addgame A link to the game here or any other message about a game
```

Then, Governor posts them daily at a specific time automatically in BB:
```
Oh ho ho, what are all these free games I've found?

A link to the game here or any other message about a game
```

There are also some helper commands:

See all the games that'll be announced
```
!getgames
```

Remove all the games to be announced (Governor does this automatically after posting)
```
!cleargames
```

### Breaking Changes
* Requires changes to `config.json` to store the new announcement channel and announcement time fields
  * Announcement time format is hh:mm AM/PM (12 hour, UTC)
  * Announcement channel format is the id of the channel
* Requires a new table in the DB: `games`
  * `CREATE TABLE games (game text)`