### PR TITLE
Ignore DLC when retrieving free epic games for the free games announcement

### DIFF
--- a/src/games.py
+++ b/src/games.py
@@ -119,6 +119,8 @@ class GameTimer:
             try:
                 name = game["title"]
                 url = game["productSlug"]
+
+                # Sometimes product slug is None, in which case this other field looks right, but it also can be None
                 if url is None and len(game["catalogNs"]["mappings"]) > 0:
                     url = game["catalogNs"]["mappings"][0]["pageSlug"]
 
@@ -130,7 +132,13 @@ class GameTimer:
                     # eg_print(f"{name}: not free, skipping")
                     continue
 
-                # When there is no promotion the promotions field is a mess:
+                # Offer type returned by the API is (so far) one of BASE_GAME, DLC, or OTHERS
+                # It is unclear what OTHERS is - assume BASE_GAME is for full games that become free
+                if game["offerType"] != "BASE_GAME":
+                    # eg_print(f"{name}: not a full game, skipping")
+                    continue
+
+                # When there is no promotion the promotions field can be different:
                 # sometimes null, sometimes an empty object, sometimes a list of no objects
                 # Wrap in try/catch and assume failing to parse it means it's not on sale rather than a parse error
                 try:


### PR DESCRIPTION
## Summary

* Use the `offerType` field to differentiate the type of thing that is free, only add `BASE_GAME` offers
* Updated some comments

Let me know if you want any changes!

## Testing

Using data for this week, only `DOOM 64` is shown (full game) - `Rumbleverse™ - Boom Boxer Content Pack` is no longer shown (DLC).

![image](https://user-images.githubusercontent.com/21993469/186299014-d947b4bd-d481-4c53-8257-9322531e44ce.png)
