### PR TITLE
game announcements: ignore free to play games

### DIFF
--- a/src/games.py
+++ b/src/games.py
@@ -93,7 +93,7 @@ class GameTimer:
     @staticmethod
     def _get_epic_games() -> list[dict[str, str]]:
         """
-        This retrieves epic games newly available for free today. US region only.
+        This retrieves epic games newly available for free today. F2P games are ignored. US region only.
         The parsing is *very* hacky, but to be fair, so is the data format.
         :return: A list of newly free games.
         """
@@ -130,6 +130,10 @@ class GameTimer:
 
                 if game["price"]["totalPrice"]["discountPrice"] != 0:
                     # eg_print(f"{name}: not free, skipping")
+                    continue
+
+                if game["price"]["totalPrice"]["originalPrice"] == 0:
+                    # eg_print(f"{name}: always free, skipping")
                     continue
 
                 # Offer type returned by the API is (so far) one of BASE_GAME, DLC, or OTHERS


### PR DESCRIPTION
## Summary

This week ([JSON](https://store-site-backend-static.ak.epicgames.com/freeGamesPromotions?country=US)), Governor posted:

* Knockout City™: https://store.epicgames.com/en-US/p/knockout-city
* Shadow of the Tomb Raider: Definitive Edition: https://store.epicgames.com/en-US/p/shadow-of-the-tomb-raider
* Submerged: Hidden Depths: https://store.epicgames.com/en-US/p/submerged-hidden-depths-6065a1

The last two are desired, but `Knockout City™` is not.

It's a free to play game; the goal is to only announce actual deals.

Presumably it shows up on the list because it's now become available on epic games.

This PR checks for games that are normally free and ignores them.

## Testing

Running with the debug print un-commented:
```
...
Knockout City™: always free, skipping
...
```