### PR TITLE
Game announcements: don't repeat the same header twice in a row

### DIFF
--- a/src/games.py
+++ b/src/games.py
@@ -42,6 +42,7 @@ class GameTimer:
         self._channel = None
         self.task = None
         self.should_add_epic_games = None
+        self._last_announcement_message = None
 
     def start(self, channel: discord.TextChannel, add_epic_games: bool):
         if self.task is None:
@@ -68,11 +69,12 @@ class GameTimer:
 
         if len(games) != 0:
             formatted_games = "\n".join(games)
-            announcement = random.choice(ANNOUNCE_MESSAGES)
+            announcement = random.choice([msg for msg in ANNOUNCE_MESSAGES if msg != self._last_announcement_message])
             message = f"{announcement}\n\n{formatted_games}"
 
             await self._channel.send(message)
             db.clear_games()
+            self._last_announcement_message = announcement
 
     @staticmethod
     async def _wait_until_next_announcement():


### PR DESCRIPTION
## Summary

This change makes Governor never repeat the same announcement header twice in a row. It would do that sometimes and I found that a bit too repetitive.

This approach is simple but won't work across reboots. That's fine IMO - it's a minor improvement not worthy of new data in the database.

Let me know if you want any changes!

## Testing

Ran Governor locally, posted a bunch of games manually, it worked and did not repeat headers.