### PR TITLE
Game announcements: remove /home from game urls to fix broken links

### DIFF
--- a/src/games.py
+++ b/src/games.py
@@ -130,6 +130,9 @@ class GameTimer:
                     eg_print(f"{name}: Could not get URL, skipping")
                     continue
 
+                # Some urls have an extra /home at the end which leads to a 404 - remove it to get the right url
+                url = url.removesuffix("/home")
+
                 if game["price"]["totalPrice"]["discountPrice"] != 0:
                     # eg_print(f"{name}: not free, skipping")
                     continue


### PR DESCRIPTION
## Summary

Some of the urls have `/home` at the end of them. These lead to pages which don't exist.

Don't know why the epic games API is doing this now, but stripping that from the url fixes the links.

## Testing

Didn't run the bot, but this should work.