### PR TITLE
Automatically execute XNBZola for linked XNB mods

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,7 @@ ASSETS_PATH = "./assets"
 FONTS_PATH = "./fonts"
 TMP_PATH = "./private/tmp"
 CMD_PREFIX = cfg['command_prefix']
+NEXUS_API_KEY = cfg['nexus_key']
 
 ADMIN_ACCESS = cfg['roles']['admin_access']
 MODDER_ROLE = cfg['roles']['modder']

--- a/src/log.py
+++ b/src/log.py
@@ -54,11 +54,12 @@ async def check_xnb_mods(message: discord.Message):
             'accept': 'application/json',
         }).json()
 
-        xnbs = flatten_index(index)
+        flat = flatten_index(index)
+        xnbs = [f for f in flat if f.name.endswith('.xnb')]
+        manifests = [f for f in flat if f.name.endswith('manifest.json')]
+        
 
-        print(xnbs)
-
-        if len(xnbs) != 0:
+        if len(xnbs) != 0 and len(manifests) == 0:
             await message.reply(custom.parse_response('xnbzola'))
         else:
             continue

--- a/src/log.py
+++ b/src/log.py
@@ -6,6 +6,10 @@ import bs4
 import discord
 import requests
 
+from config import NEXUS_API_KEY
+import custom
+from utils import flatten_index
+
 # Template for SMAPI log info messages
 smapi_log_message_template = string.Template(
     "**Log Info:** SMAPI $SMAPI_ver with SDV $StardewVersion on $OS, "
@@ -32,6 +36,33 @@ async def check_attachments(message: discord.Message):
             s = requests.post('https://smapi.io/log/', data="input={0}".format(log), headers=headers)
             logurl = s.text.split('</strong> <code>')[1].split('</code>')[0]
             await message.channel.send("Log found, uploaded to: " + logurl)
+
+async def check_xnb_mods(message: discord.Message):
+    for mod_id in re.findall(r"https://www\.nexusmods\.com/stardewvalley/mods/(\d+)", message.content.replace("<", "").replace(">", "")):
+        mod_id = mod_id.strip()
+        files_endpoint = f'https://api.nexusmods.com/v1/games/stardewvalley/mods/{mod_id}/files.json"'
+        
+        files_info = requests.get(files_endpoint, params={
+            'category': 'main'
+        }, headers={
+            'accept': 'application/json',
+            'apikey': NEXUS_API_KEY
+        }).json()
+        
+        index_url = files_info['files'][0]['content_preview_link']
+        index = requests.get(index_url, headers={
+            'accept': 'application/json',
+        }).json()
+
+        xnbs = flatten_index(index)
+
+        print(xnbs)
+
+        if len(xnbs) != 0:
+            await message.reply(custom.parse_response('xnbzola'))
+        else:
+            continue
+        break
 
 def _parse_log(url):
     r = requests.get(url)

--- a/src/main.py
+++ b/src/main.py
@@ -98,6 +98,7 @@ async def on_message(message: discord.Message):
     # Check if the user has uploaded SMAPI diagnostic info
     await log.check_log_link(message)
     await log.check_attachments(message)
+    await log.check_xnb_mods(message)
 
     # Check if someone is trying to use a custom command
     if message.content != "" and message.content[0] == CMD_PREFIX:

--- a/src/utils.py
+++ b/src/utils.py
@@ -65,3 +65,23 @@ def to_thread(func: Callable) -> Coroutine:
     async def wrapper(*args, **kwargs):
         return await asyncio.to_thread(func, *args, **kwargs)
     return wrapper
+
+"""
+Flatten Nexus Files Index
+
+Flattens the Nexusmods file index to be a single array of files with no directories or sub-arrays.
+"""
+def flatten_index(index):
+    result = []
+
+    def _flatten(node):
+        if 'children' in node:
+            for child in node['children']:
+                _flatten(child)
+        elif 'type' in node and node['type'] == 'file' and node['name'].endswith('xnb'):
+            result.append(node)
+
+    for child in index['children']:
+        _flatten(child)
+
+    return result

--- a/src/utils.py
+++ b/src/utils.py
@@ -71,14 +71,14 @@ Flatten Nexus Files Index
 
 Flattens the Nexusmods file index to be a single array of files with no directories or sub-arrays.
 """
-def flatten_index(index):
+def flatten_index(index: list) -> list:
     result = []
 
     def _flatten(node):
         if 'children' in node:
             for child in node['children']:
                 _flatten(child)
-        elif 'type' in node and node['type'] == 'file' and node['name'].endswith('xnb'):
+        elif 'type' in node and node['type'] == 'file':
             result.append(node)
 
     for child in index['children']:


### PR DESCRIPTION
Automatically check if a linked mod contains `.xnb` files **and not** a `manifest.json` and automatically sends the `!xnbzola` command in response.
The bot now needs a Nexusmods API key to be ran, specified in the config with `nexus_key`. One can be obtained from https://next.nexusmods.com/settings/api-keys.