### PR TITLE
Fix keyerror & error when files not present.

### DIFF
--- a/src/log.py
+++ b/src/log.py
@@ -49,14 +49,17 @@ async def check_xnb_mods(message: discord.Message):
             'apikey': NEXUS_API_KEY
         }).json()
         
+        if len(files_info['files']) == 0: 
+            continue
+        
         index_url = files_info['files'][0]['content_preview_link']
         index = requests.get(index_url, headers={
             'accept': 'application/json',
         }).json()
 
         flat = flatten_index(index)
-        xnbs = [f for f in flat if f.name.endswith('.xnb')]
-        manifests = [f for f in flat if f.name.endswith('manifest.json')]
+        xnbs = [f for f in flat if f['name'].endswith('.xnb')]
+        manifests = [f for f in flat if f['name'].endswith('manifest.json')]
         
 
         if len(xnbs) != 0 and len(manifests) == 0:


### PR DESCRIPTION
It was broken because javascript made me not use `dict['key']`